### PR TITLE
Updated import of zod to be more treeshakable

### DIFF
--- a/docs/guide/data/form.md
+++ b/docs/guide/data/form.md
@@ -136,7 +136,7 @@ updateTodo.$onSaved(() => emit('close'))
 Both `createForm` and `updateForm` methods will by default validate the data using the model's schemas [see more info here](../model/model.md#schema-validation). You can override the schema by passing a new schema to the form object:
 
 ```ts
-import { z } from 'zod'
+import * as z from 'zod'
 
 const createTodo = store.todos.createForm({
   schema: z.object({


### PR DESCRIPTION
I updated the import of zod to be tree shakable, see comment: https://github.com/colinhacks/zod/issues/2596#issuecomment-1729983383

Background: I think it is important for docs to show best practices :) Following this principle I would advise not to show Zod in the first place because it is not treeshakable. A (very) good alternative, that is treeshakable, would be Valibot: https://github.com/fabian-hiller/valibot